### PR TITLE
add thread_memory_count to count number of rust allocations

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-rust-allocator-proxy"
-version = "0.2.1"
+version = "0.2.5"
 authors = ["Piotr Mikulski <piotr@near.org>"]
 edition = "2018"
 

--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -153,6 +153,11 @@ pub fn thread_memory_usage(tid: usize) -> usize {
     memory_usage
 }
 
+pub fn thread_memory_count(tid: usize) -> usize {
+    let memory_cnt = MEM_CNT[tid % COUNTERS_SIZE].load(Ordering::SeqCst);
+    memory_cnt
+}
+
 pub fn current_thread_peak_memory_usage() -> usize {
     MEMORY_USAGE_MAX.with(|x| *x.borrow())
 }


### PR DESCRIPTION
It will be useful to print number of rust allocations done on given thread