### PR TITLE
disable calculating stack traces on mac

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-rust-allocator-proxy"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Piotr Mikulski <piotr@near.org>"]
 edition = "2018"
 


### PR DESCRIPTION
Currently there is no need to do stack traces on mac, so let's disable it by default.