### PR TITLE
add a way to Report usage of memory through malloc

### DIFF
--- a/near-dump-analyzer/Makefile
+++ b/near-dump-analyzer/Makefile
@@ -29,7 +29,7 @@ run: all
 	nearup stop
 	rm -rf logs
 	mkdir -p logs
-	LD_PRELOAD=./bins/near-c-allocator-proxy.so nohup nice -10 nearup run $(NETWORK) --binary-path $(REPO_PATH)/target/release $(EXTRA)
+	LD_PRELOAD=${PWD}/bins/near-c-allocator-proxy.so nohup nice -10 nearup run $(NETWORK) --binary-path $(REPO_PATH)/target/release $(EXTRA)
 
 
 dump: all
@@ -39,4 +39,4 @@ dump: all
 	mkdir -p symbols || true;
 	test -f symbols/${PID} || (echo maint print psymbols | sudo gdb -p "${PID}" >> "symbols/${PID}");
 	test -f symbols/${PID}.m || (echo maint print msymbols | sudo gdb -p "${PID}" >> "symbols/${PID}.m");
-	sudo ./bins/dump "${PID}"
+	sudo ${PWD}/bins/dump "${PID}"

--- a/near-dump-analyzer/near-c-allocator-proxy.c
+++ b/near-dump-analyzer/near-c-allocator-proxy.c
@@ -14,7 +14,6 @@
 #include <sys/types.h>
 
 
-
 const int ALLOC_LIMIT = 100;
 
 thread_local FILE * file = 0;
@@ -106,7 +105,6 @@ void print_trace2(void) {
 */
 
 void * get_trace(int64_t alloc_size) {
-
     if (alloc_size < ALLOC_LIMIT && (rand() % 100 != 0 && last_size == alloc_size)) {
     // if (alloc_size != 128 && alloc_size < ALLOC_LIMIT && (rand() % 100 != 0)) {
         return (void *)1;
@@ -146,6 +144,15 @@ void *malloc(size_t size)
 {
 
 #ifdef COUNT_BYTES
+    if (size == (~(size_t)0)) {
+        // hack used to report memory usage bytes
+        return (void *)mem_allocated_bytes;
+    }
+    if (size == (~(size_t)0) - 1) {
+        // hack used to report memory usage count
+        return (void *)mem_allocated_cnt;
+    }
+
     void *ptr = __libc_malloc(size + ALIGN);
     if (ptr)  {
         if (tid == 0) tid = gettid();


### PR DESCRIPTION
We currently have to way of reporting memory usage for C code. I added a hack to malloc, given value of MAX_VAL or MAX_VAL -2, it will report size of all memory allocations or count of all memory allocations.