### PR TITLE
fix C allocator proxy to log mmap operations

### DIFF
--- a/near-dump-analyzer/near-c-allocator-proxy.c
+++ b/near-dump-analyzer/near-c-allocator-proxy.c
@@ -62,7 +62,7 @@ static void thread_init() {
     if (file == NULL) {
 	if (tid == 0) tid = gettid();
 	char buf[1000];
-	sprintf(buf, "logs/%ld", tid);
+	sprintf(buf, "/tmp/dump/logs/%ld", tid);
 	file = fopen(buf, "w");
 	fprintf(file, "initializing tid: %ld\n", tid);
     }


### PR DESCRIPTION
C allocator proxy was logging data in wrong folder, this broke how we compute memory usage for RocksDB.