### PR TITLE
add total_memory_usage method to allocator.rs

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-rust-allocator-proxy"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Near Inc <hello@nearprotocol.com>", "Piotr Mikulski <piotr@near.org>"]
 description = "Rust allocator proxy with added header"
 readme = "README.md"


### PR DESCRIPTION
We currently have no way of knowing what the total size of all Rust allocation is. In this PR we add a method to query total size of all Rust allocations.