### PR TITLE
Fix a warnings inside documentation about missing `;`

### DIFF
--- a/near-rust-allocator-proxy/README.md
+++ b/near-rust-allocator-proxy/README.md
@@ -5,7 +5,7 @@ See https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html
 You can use code below to enable usage of this library:
 ```rust
 use near_rust_allocator_proxy::allocator::MyAllocator;
-use jemallocator::Jemalloc
+use jemallocator::Jemalloc;
 
 #[global_allocator]
 static ALLOC: MyAllocator<Jemalloc> = MyAllocator::new(Jemalloc);


### PR DESCRIPTION
There was a small warnings in the documentation. Let's fix that.