### PR TITLE
Add empty `dump-analyer` in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
-    "near-rust-allocator-proxy"
+    "near-rust-allocator-proxy",
+    "dump-analyzer"
 ]
 
 [profile.release]

--- a/dump-analyzer/Cargo.toml
+++ b/dump-analyzer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dump_analyzer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.51"
+clap = "=3.0.0-beta.2"
+clap_derive = "=3.0.0-beta.2"

--- a/dump-analyzer/src/main.rs
+++ b/dump-analyzer/src/main.rs
@@ -1,0 +1,17 @@
+mod opts;
+
+use crate::diff_splitter::handle_diff_splitter;
+use crate::opts::{Opts, SubCommand};
+use anyhow::Result;
+use clap::Clap;
+
+fn main() -> Result<()> {
+    let opts: Opts = Opts::parse();
+
+    match opts.subcmd {
+        SubCommand::Empty(empty_cmd) => {
+            empty_cmd.handle()
+        }
+    }
+    Ok(())
+}

--- a/dump-analyzer/src/opts.rs
+++ b/dump-analyzer/src/opts.rs
@@ -1,0 +1,27 @@
+use std::io::Empty;
+use clap::{AppSettings, Clap};
+use anyhow::Result;
+
+#[derive(Clap, Debug)]
+#[clap(version = "0.1")]
+#[clap(setting = AppSettings::SubcommandRequiredElseHelp)]
+pub(crate) struct Opts {
+    #[clap(subcommand)]
+    pub subcmd: SubCommand,
+}
+
+#[derive(Clap, Debug)]
+pub(super) enum SubCommand {
+    #[clap(name = "refactor_deepsize")]
+    Empty(EmptyCmd),
+}
+
+#[derive(Clap, Debug)]
+pub(crate) struct EmptyCmd {}
+
+impl EmptyCmd {
+    fn handle(&self) -> Result<()> {
+        println!("Hello World");
+        Ok(())
+    }
+}


### PR DESCRIPTION
Let's take the first step, and create an empty `dump-analyer` in Rust.