### PR TITLE
feat: `near-rust-allocator-proxy` Bump version to 0.3.1

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-rust-allocator-proxy"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Near Inc <hello@nearprotocol.com>", "Piotr Mikulski <piotr@near.org>"]
 description = "Rust allocator proxy with added header"
 readme = "README.md"


### PR DESCRIPTION
Let's bump `near-rust-allocator-proxy` version to `0.3.1` and do the release.