### PR TITLE
`near-dump-analyzer`: Upgrade `clap` to `3.0.0-beta5`

### DIFF
--- a/dump-analyzer/Cargo.toml
+++ b/dump-analyzer/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.51"
-clap = "=3.0.0-beta.2"
-clap_derive = "=3.0.0-beta.2"
+clap = "=3.0.0-beta.5"
+clap_derive = "=3.0.0-beta.5"

--- a/dump-analyzer/src/main.rs
+++ b/dump-analyzer/src/main.rs
@@ -3,15 +3,13 @@ mod opts;
 use crate::diff_splitter::handle_diff_splitter;
 use crate::opts::{Opts, SubCommand};
 use anyhow::Result;
-use clap::Clap;
+use clap::Parser;
 
 fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
 
     match opts.subcmd {
-        SubCommand::Empty(empty_cmd) => {
-            empty_cmd.handle()
-        }
+        SubCommand::Empty(empty_cmd) => empty_cmd.handle(),
     }
     Ok(())
 }

--- a/dump-analyzer/src/opts.rs
+++ b/dump-analyzer/src/opts.rs
@@ -1,8 +1,8 @@
-use std::io::Empty;
-use clap::{AppSettings, Clap};
 use anyhow::Result;
+use clap::AppSettings;
+use std::io::Empty;
 
-#[derive(Clap, Debug)]
+#[derive(clap::Parser, Debug)]
 #[clap(version = "0.1")]
 #[clap(setting = AppSettings::SubcommandRequiredElseHelp)]
 pub(crate) struct Opts {
@@ -10,13 +10,13 @@ pub(crate) struct Opts {
     pub subcmd: SubCommand,
 }
 
-#[derive(Clap, Debug)]
+#[derive(clap::Parser, Debug)]
 pub(super) enum SubCommand {
     #[clap(name = "refactor_deepsize")]
     Empty(EmptyCmd),
 }
 
-#[derive(Clap, Debug)]
+#[derive(clap::Parser, Debug)]
 pub(crate) struct EmptyCmd {}
 
 impl EmptyCmd {


### PR DESCRIPTION
It's a good idea to update clap to the latest version.