### PR TITLE
Specify `rust version` for the project

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# Please update rust-version in **/Cargo.toml files when changing channel:
+channel = "1.57.0"
+components = [ "rustfmt" ]


### PR DESCRIPTION
It's a good idea to specify `rust-version` for the project. This ensures, that everyone building the project locally, will have the right rust version installed.