### PR TITLE
Add `rustfmt.toml`

### DIFF
--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -294,14 +294,10 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for MyAllocator<A> {
                         if SAVE_STACK_TRACES_TO_FILE {
                             let fname = format!("/tmp/logs/{}", tid);
 
-                            if let Ok(mut f) = OpenOptions::new()
-                                .create(true)
-                                .write(true)
-                                .append(true)
-                                .open(fname)
+                            if let Ok(mut f) =
+                                OpenOptions::new().create(true).write(true).append(true).open(fname)
                             {
-                                f.write(format!("STACK_FOR {:?}\n", addr).as_bytes())
-                                    .unwrap();
+                                f.write(format!("STACK_FOR {:?}\n", addr).as_bytes()).unwrap();
                                 let ary2: [*mut c_void; 256] =
                                     [std::ptr::null_mut::<c_void>(); 256];
                                 let size2 = libc::backtrace(ary2.as_ptr() as *mut *mut c_void, 256)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+use_small_heuristics = "Max"
+reorder_imports = true
+edition = "2021"
+# This option will merge imports, however it's only available in +nightly.
+# imports_granularity = "Module"
+# fn_args_density = "Compressed"
+# overflow_delimited_expr = "true"


### PR DESCRIPTION
Let's add `rustfmt.toml` to improve code quality.