### PR TITLE
re: Fix clippy warnings about `write!`

### DIFF
--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -263,9 +263,9 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for MyAllocator<A> {
                                     .open(fname)
                                 {
                                     if let Some(path) = symbol.filename() {
-                                        write!(
+                                        writeln!(
                                             f,
-                                            "PATH {:?} {} {}\n",
+                                            "PATH {:?} {} {}",
                                             ary[i],
                                             symbol.lineno().unwrap_or(0),
                                             path.to_str().unwrap_or("<UNKNOWN>")
@@ -273,7 +273,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for MyAllocator<A> {
                                         .unwrap();
                                     }
                                     if let Some(name) = symbol.name() {
-                                        write!(f, "SYMBOL {:?} {}\n", ary[i], name.to_string())
+                                        writeln!(f, "SYMBOL {:?} {}", ary[i], name.to_string())
                                             .unwrap();
                                     }
                                 }
@@ -293,7 +293,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for MyAllocator<A> {
                             if let Ok(mut f) =
                                 OpenOptions::new().create(true).write(true).append(true).open(fname)
                             {
-                                write!(f, "STACK_FOR {:?}\n", addr).unwrap();
+                                writeln!(f, "STACK_FOR {:?}", addr).unwrap();
                                 let ary2: [*mut c_void; 256] = [null_mut::<c_void>(); 256];
                                 let size2 = libc::backtrace(ary2.as_ptr() as *mut *mut c_void, 256)
                                     as usize;
@@ -304,7 +304,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for MyAllocator<A> {
                                         if let Some(name) = symbol.name() {
                                             let name = name.as_str().unwrap_or("");
 
-                                            write!(f, "STACK {:?} {:?} {:?}\n", i, addr2, name)
+                                            writeln!(f, "STACK {:?} {:?} {:?}", i, addr2, name)
                                                 .unwrap();
                                         }
                                     });


### PR DESCRIPTION
Clippy reports a warning about using `write!` with a format string that ends with a new line. We can total reduce number of warnings from 7 to 3.

```
warning: using `write!()` with a format string that ends in a single newline
   --> near-rust-allocator-proxy/src/allocator.rs:296:33
    |
296 | ...                   write!(f, "STACK_FOR {:?}\n", addr).unwrap();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#write_with_newline
help: use `writeln!()` instead
```