### PR TITLE
re: Switch to `tracing` style of `info!` messages

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1.13"
 [dev-dependencies]
 criterion = "0.3.5"
 tikv-jemallocator = "0.4.1"
+tracing-subscriber = "0.3.3"
 
 [[bench]]
 name = "allocations"


### PR DESCRIPTION
We recently switched to using `tracing` in favor of `log`.
We should change the format of log messages as well.