### PR TITLE
Remove usage of `rand`.

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2021"
 backtrace = "0.3"
 libc = "0.2.65"
 nix = "0.15.0"
-rand = "0.7.3"
 tracing = "0.1.13"
 
 [dev-dependencies]


### PR DESCRIPTION
By removing usage of `rand::thread_rng().gen_range(0, 100)`, we are able to improve performance by 20%.

Before the change:
```
alloc_32                time:   [38.347 ns 38.375 ns 38.403 ns]    
alloc_32                time:   [38.509 ns 38.552 ns 38.595 ns]        
alloc_32                time:   [38.185 ns 38.227 ns 38.269 ns]   
```

After the change:
```
alloc_32                time:   [32.702 ns 32.715 ns 32.729 ns] 
alloc_32                time:   [31.171 ns 31.230 ns 31.296 ns]  
alloc_32                time:   [31.506 ns 31.524 ns 31.546 ns]                  
````

Baseline, when not using custom allocator proxy
```
alloc_32                time:   [7.1161 ns 7.1201 ns 7.1262 ns]    
```