### PR TITLE
Define public api for `allocator` / bump version to `0.4.0`

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-rust-allocator-proxy"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Near Inc <hello@nearprotocol.com>", "Piotr Mikulski <piotr@near.org>"]
 description = "Rust allocator proxy with added header"
 readme = "README.md"

--- a/near-rust-allocator-proxy/benches/allocations.rs
+++ b/near-rust-allocator-proxy/benches/allocations.rs
@@ -1,4 +1,4 @@
-use near_rust_allocator_proxy::allocator::MyAllocator;
+use near_rust_allocator_proxy::MyAllocator;
 
 #[global_allocator]
 static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
@@ -9,7 +9,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 fn alloc_1024(c: &mut Criterion) {
     c.bench_function("alloc_1024", |b| {
         b.iter(|| {
-            black_box(Vec::<u8>::with_capacity(1024));
+            black_box(vec![1024, 0]);
         })
     });
 }

--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -59,11 +59,11 @@ const MAGIC_RUST: usize = 0x12345678991100;
 const FREED_MAGIC: usize = 0x100;
 
 thread_local! {
-    pub static TID: Cell<usize> = Cell::new(0);
-    pub static IN_TRACE: Cell<usize> = Cell::new(0);
-    pub static MEMORY_USAGE_MAX: Cell<usize> = Cell::new(0);
-    pub static MEMORY_USAGE_LAST_REPORT: Cell<usize> = Cell::new(0);
-    pub static NUM_ALLOCATIONS: Cell<usize> = Cell::new(0);
+    static TID: Cell<usize> = Cell::new(0);
+    static IN_TRACE: Cell<usize> = Cell::new(0);
+    static MEMORY_USAGE_MAX: Cell<usize> = Cell::new(0);
+    static MEMORY_USAGE_LAST_REPORT: Cell<usize> = Cell::new(0);
+    static NUM_ALLOCATIONS: Cell<usize> = Cell::new(0);
 }
 
 #[cfg(target_os = "linux")]
@@ -79,7 +79,7 @@ pub fn get_tid() -> usize {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub static NTHREADS: AtomicUsize = AtomicUsize::new(0);
+static NTHREADS: AtomicUsize = AtomicUsize::new(0);
 #[cfg(not(target_os = "linux"))]
 pub fn get_tid() -> usize {
     let res = TID.with(|t| {

--- a/near-rust-allocator-proxy/src/lib.rs
+++ b/near-rust-allocator-proxy/src/lib.rs
@@ -1,1 +1,7 @@
-pub mod allocator;
+mod allocator;
+
+pub use allocator::{
+    current_thread_memory_usage, current_thread_peak_memory_usage, print_counters_ary,
+    reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
+    MyAllocator,
+};


### PR DESCRIPTION
Some variables/functions don't need to be public.

We are going to change the api, before we do that, lets add
```
pub use allocator::{
    current_thread_memory_usage, current_thread_peak_memory_usage, print_counters_ary,
    reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
    MyAllocator,
};
```

This is a breaking change / bumping version to `0.4.0`.