### PR TITLE
Rename function in API for `allocator` / bump version `0.4.0`

### DIFF
--- a/near-rust-allocator-proxy/benches/allocations.rs
+++ b/near-rust-allocator-proxy/benches/allocations.rs
@@ -1,8 +1,8 @@
-use near_rust_allocator_proxy::MyAllocator;
+use near_rust_allocator_proxy::ProxyAllocator;
 
 #[global_allocator]
-static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
-    MyAllocator::new(tikv_jemallocator::Jemalloc);
+static ALLOC: ProxyAllocator<tikv_jemallocator::Jemalloc> =
+    ProxyAllocator::new(tikv_jemallocator::Jemalloc);
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 

--- a/near-rust-allocator-proxy/src/lib.rs
+++ b/near-rust-allocator-proxy/src/lib.rs
@@ -2,9 +2,9 @@ mod allocator;
 mod config;
 
 pub use allocator::{
-    current_thread_memory_usage, current_thread_peak_memory_usage, print_counters_ary,
+    current_thread_memory_usage, current_thread_peak_memory_usage, print_memory_stats,
     reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
-    MyAllocator,
+    ProxyAllocator,
 };
 
 pub use config::AllocatorConfig;


### PR DESCRIPTION
It's a good time to decide what the naming should be for the public api.

Changed:
- `MyAllocator` -> `ProxyAllocator`
- `print_counters_ary` -> `print_memory_stats`

```
   current_thread_memory_usage, current_thread_peak_memory_usage, print_memory_stats,
    reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
    ProxyAllocator,
```