### PR TITLE
Add `config.rs` with settings for allocator

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 backtrace = "0.3"
 nix = "0.15.0"
 tracing = "0.1.13"
+once_cell = "1"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/near-rust-allocator-proxy/src/config.rs
+++ b/near-rust-allocator-proxy/src/config.rs
@@ -1,0 +1,43 @@
+use crate::allocator::{ENABLE_STACK_TRACE, REPORT_USAGE_INTERVAL, SAVE_STACK_TRACES_TO_FILE};
+use std::sync::atomic::Ordering;
+
+#[derive(Default)]
+pub struct AllocatorConfig {}
+
+impl AllocatorConfig {
+    /// Enable calling `backtrace` to fill out data
+    pub fn enable_stack_trace(self, value: bool) -> Self {
+        ENABLE_STACK_TRACE.store(value, Ordering::Relaxed);
+        self
+    }
+
+    /// Save stack tres to file
+    pub fn save_stack_traces_to_file(self, value: bool) -> Self {
+        SAVE_STACK_TRACES_TO_FILE.store(value, Ordering::Relaxed);
+        self
+    }
+
+    /// Save stack tres to file
+    pub fn set_report_usage_interval(self, value: usize) -> Self {
+        REPORT_USAGE_INTERVAL.store(value, Ordering::Relaxed);
+        self
+    }
+
+    /// Set file where to write stack traces
+    pub fn set_traces_file(self, _file_path: &str) -> Self {
+        panic!("NOT IMPLEMENTED");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AllocatorConfig;
+
+    #[test]
+    fn test() {
+        let _ = AllocatorConfig::default()
+            .save_stack_traces_to_file(true)
+            .set_report_usage_interval(10000000)
+            .enable_stack_trace(false);
+    }
+}

--- a/near-rust-allocator-proxy/src/config.rs
+++ b/near-rust-allocator-proxy/src/config.rs
@@ -1,4 +1,6 @@
-use crate::allocator::{ENABLE_STACK_TRACE, REPORT_USAGE_INTERVAL, SAVE_STACK_TRACES_TO_FILE};
+use crate::allocator::{
+    ENABLE_STACK_TRACE, LOGS_PATH, REPORT_USAGE_INTERVAL, SAVE_STACK_TRACES_TO_FILE,
+};
 use std::sync::atomic::Ordering;
 
 #[derive(Default)]
@@ -25,7 +27,8 @@ impl AllocatorConfig {
 
     /// Set file where to write stack traces
     pub fn set_traces_file(self, _file_path: &str) -> Self {
-        panic!("NOT IMPLEMENTED");
+        *LOGS_PATH.lock().unwrap() = _file_path.to_string();
+        self
     }
 }
 

--- a/near-rust-allocator-proxy/src/lib.rs
+++ b/near-rust-allocator-proxy/src/lib.rs
@@ -1,7 +1,10 @@
 mod allocator;
+mod config;
 
 pub use allocator::{
     current_thread_memory_usage, current_thread_peak_memory_usage, print_counters_ary,
     reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
     MyAllocator,
 };
+
+pub use config::AllocatorConfig;


### PR DESCRIPTION
Add a config, which can be used to configure allocator settings.