### PR TITLE
Compiler bug

### DIFF
--- a/near-rust-allocator-proxy/benches/allocations.rs
+++ b/near-rust-allocator-proxy/benches/allocations.rs
@@ -1,8 +1,8 @@
-use near_rust_allocator_proxy::MyAllocator;
+use near_rust_allocator_proxy::ProxyAllocator;
 
 #[global_allocator]
-static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
-    MyAllocator::new(tikv_jemallocator::Jemalloc);
+static ALLOC: ProxyAllocator<tikv_jemallocator::Jemalloc> =
+    ProxyAllocator::new(tikv_jemallocator::Jemalloc);
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 

--- a/near-rust-allocator-proxy/src/lib.rs
+++ b/near-rust-allocator-proxy/src/lib.rs
@@ -4,7 +4,7 @@ mod config;
 pub use allocator::{
     current_thread_memory_usage, current_thread_peak_memory_usage, print_counters_ary,
     reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
-    MyAllocator,
+    ProxyAllocator,
 };
 
 pub use config::AllocatorConfig;


### PR DESCRIPTION
This causes `cargo check` to fail.

```console
.~/r/near-memory-tracker compiler-bug NO_REMOTE RUST_BACKTRACE=1 cargo check
    Checking near-rust-allocator-proxy v0.4.0 (/home/pmnoxx/repos/near-memory-tracker/near-rust-allocator-proxy)
thread 'rustc' panicked at 'called `Option::unwrap()` on a `None` value', /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/compiler/rustc_hir/src/definitions.rs:452:14
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:100:14
   2: core::panicking::panic
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:50:5
   3: <rustc_query_impl::on_disk_cache::OnDiskCache as rustc_middle::ty::context::OnDiskCache>::def_path_hash_to_def_id
   4: rustc_middle::dep_graph::dep_node::<impl rustc_query_system::dep_graph::dep_node::DepNodeParams<rustc_middle::ty::context::TyCtxt> for rustc_span::def_id::LocalDefId>::recover
   5: rustc_query_impl::query_callbacks::hir_owner::force_from_dep_node
   6: rustc_query_system::dep_graph::graph::DepGraph<K>::try_mark_previous_green
   7: rustc_query_system::dep_graph::graph::DepGraph<K>::try_mark_previous_green
   8: rustc_query_system::query::plumbing::ensure_must_run
   9: <rustc_query_impl::Queries as rustc_middle::ty::query::QueryEngine>::check_match
  10: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
  11: rustc_data_structures::sync::par_for_each_in
  12: rustc_session::utils::<impl rustc_session::session::Session>::time
  13: rustc_interface::passes::analysis
  14: rustc_query_system::dep_graph::graph::DepGraph<K>::with_task
  15: rustc_data_structures::stack::ensure_sufficient_stack
  16: rustc_query_system::query::plumbing::try_execute_query
  17: <rustc_query_impl::Queries as rustc_middle::ty::query::QueryEngine>::analysis
  18: rustc_interface::passes::QueryContext::enter
  19: rustc_interface::queries::<impl rustc_interface::interface::Compiler>::enter
  20: rustc_span::with_source_map
  21: scoped_tls::ScopedKey<T>::set
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.57.0 (f1edd0429 2021-11-29) running on x86_64-unknown-linux-gnu

note: compiler flags: -C embed-bitcode=no -C debuginfo=2 -C incremental --crate-type lib

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [analysis] running analysis passes on this crate
end of query stack
error: could not compile `near-rust-allocator-proxy`

```