### PR TITLE
re: `allocator` - make `AllocHeader` public

### DIFF
--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 backtrace = "0.3"
-nix = "0.15.0"
+nix = ">=0.15,<=0.23"
 tracing = "0.1.13"
 once_cell = "1"
 

--- a/near-rust-allocator-proxy/src/lib.rs
+++ b/near-rust-allocator-proxy/src/lib.rs
@@ -4,7 +4,7 @@ mod config;
 pub use allocator::{
     current_thread_memory_usage, current_thread_peak_memory_usage, print_memory_stats,
     reset_memory_usage_max, thread_memory_count, thread_memory_usage, total_memory_usage,
-    ProxyAllocator,
+    AllocHeader, ProxyAllocator, ALLOC_HEADER_SIZE,
 };
 
 pub use config::AllocatorConfig;


### PR DESCRIPTION
We need to make `AllocHeader` public, that is needed to allow writing dump analyzer in `Rust`.