### PR TITLE
re: Improve `rust.yaml` workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: '-D warnings'
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: short
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,10 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: '-D warnings'
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
 
     steps:
@@ -26,10 +26,9 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-build
     - name: Build
-      run: RUSTFLAGS='-D warnings' cargo build --verbose --workspace
+      run: cargo build --verbose --workspace
 
   tests:
-
     runs-on: ubuntu-20.04
 
     steps:
@@ -44,10 +43,9 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-tests
     - name: Run tests
-      run: RUSTFLAGS='-D warnings' cargo test --verbose --workspace
+      run: cargo test --verbose --workspace
 
   clippy:
-
     runs-on: ubuntu-20.04
 
     steps:
@@ -62,13 +60,9 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy
     - name: Run clippy
-      run: |
-        pwd
-        echo *
-        cargo clippy --all-targets -- -D clippy::all
+      run: cargo clippy --all-targets -- -D clippy::all
 
   cargo-deny:
-
     runs-on: ubuntu-20.04
 
     steps:
@@ -85,11 +79,9 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-cargo-deny
     - name: Install cargo-deny
       if: steps.deny-cache.outputs.cache-hit != 'true'
-      run: |
-        cargo install cargo-deny
+      run: cargo install cargo-deny
     - name: Run cargo-deny
-      run: |
-        cargo-deny --all-features --workspace check Advisories Bans Sources
+      run: cargo-deny --all-features --workspace check Advisories Bans Sources
 
   cargo-fmt:
     runs-on: ubuntu-20.04

--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -210,7 +210,7 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for ProxyAllocator<A> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let tid = get_tid();
         let new_layout =
-            Layout::from_size_align((layout.size() + ALLOC_HEADER_SIZE), layout.align()).unwrap();
+            Layout::from_size_align(layout.size() + ALLOC_HEADER_SIZE, layout.align()).unwrap();
 
         let res = self.inner.alloc(new_layout);
         let memory_usage = MEM_SIZE[tid % COUNTERS_SIZE]


### PR DESCRIPTION
We can make `rust.yaml` better by

- adding common `RUSTFLAGS: '-D warnings'`
- `CARGO_INCEMENTAL`: 0
- `RUST_BACKTRACE: short`
- cleaning up `run` 