### PR TITLE
re: Remove saving traces to file

### DIFF
--- a/near-rust-allocator-proxy/src/config.rs
+++ b/near-rust-allocator-proxy/src/config.rs
@@ -1,6 +1,4 @@
-use crate::allocator::{
-    ENABLE_STACK_TRACE, LOGS_PATH, REPORT_USAGE_INTERVAL, SAVE_STACK_TRACES_TO_FILE,
-};
+use crate::allocator::{ENABLE_STACK_TRACE, REPORT_USAGE_INTERVAL};
 use std::sync::atomic::Ordering;
 
 #[derive(Default)]
@@ -14,20 +12,8 @@ impl AllocatorConfig {
     }
 
     /// Save stack tres to file
-    pub fn save_stack_traces_to_file(self, value: bool) -> Self {
-        SAVE_STACK_TRACES_TO_FILE.store(value, Ordering::Relaxed);
-        self
-    }
-
-    /// Save stack tres to file
     pub fn set_report_usage_interval(self, value: usize) -> Self {
         REPORT_USAGE_INTERVAL.store(value, Ordering::Relaxed);
-        self
-    }
-
-    /// Set file where to write stack traces
-    pub fn set_traces_file(self, _file_path: &str) -> Self {
-        *LOGS_PATH.lock().unwrap() = _file_path.to_string();
         self
     }
 }
@@ -39,7 +25,6 @@ mod tests {
     #[test]
     fn test() {
         let _ = AllocatorConfig::default()
-            .save_stack_traces_to_file(true)
             .set_report_usage_interval(10000000)
             .enable_stack_trace(false);
     }


### PR DESCRIPTION
Saving stack traces to file is no longer needed. The new `rust-memory-analyzer` is able to recover symbols without need for process to save them to a file.

Closes #88 