### PR TITLE
Ignore RUSTSEC-2021-0127

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,7 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    "RUSTSEC-2021-0127",
     #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score


### PR DESCRIPTION
Add ignore `RUSTSEC-2021-0127` advisory in `deny.toml`.