### PR TITLE
feat: Test new workflow targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,23 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
+  build-macos-11:
+    runs-on: macos-11
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-build
+    - name: Build
+      run: cargo build --verbose --workspace
+
   build-windows-2022:
     runs-on: windows-2022
 
@@ -29,7 +46,7 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-build
     - name: Build
       run: cargo build --verbose --workspace
-  build:
+  build-ubunut-20-04:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,22 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
+  build-windows-2022:
+    runs-on: windows-2022
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-build
+    - name: Build
+      run: cargo build --verbose --workspace
   build:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
Add build to pipeline, to make sure library build on `macos-11` and `windows-2022`.