### PR TITLE
feat: Add test for bug found

### DIFF
--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -350,7 +350,9 @@ pub fn print_memory_stats() {
 #[cfg(test)]
 mod test {
     use crate::allocator::{print_memory_stats, total_memory_usage, ProxyAllocator};
+    use crate::AllocHeader;
     use std::alloc::{GlobalAlloc, Layout};
+    use std::mem;
     use std::ptr::null_mut;
     use tracing_subscriber::util::SubscriberInitExt;
 
@@ -379,8 +381,23 @@ mod test {
     #[test]
     #[serial_test::serial]
     fn test_alignment() {
-        for i in 0..16 {
-            let alignment = 1 << i;
+        for alignment in (0..16).map(|i| 1 << i) {
+            let layout = Layout::from_size_align(alignment, alignment).unwrap();
+            let ptr = unsafe { ALLOC.alloc(layout) };
+            assert_ne!(ptr, null_mut());
+
+            assert_eq!(total_memory_usage(), alignment);
+            assert_eq!(ptr as usize % alignment, 0);
+
+            unsafe { ALLOC.dealloc(ptr, layout) };
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_alignment_with_offset() {
+        let header_size = mem::size_of::<AllocHeader>();
+        for alignment in (0..16).map(|i| 1 << i).filter(|&p| p >= header_size) {
             let layout = Layout::from_size_align(alignment, alignment).unwrap();
             let ptr = unsafe { ALLOC.alloc(layout) };
             assert_ne!(ptr, null_mut());

--- a/near-rust-allocator-proxy/src/allocator.rs
+++ b/near-rust-allocator-proxy/src/allocator.rs
@@ -381,15 +381,16 @@ mod test {
     #[test]
     #[serial_test::serial]
     fn test_alignment() {
-        for alignment in (0..16).map(|i| 1 << i) {
-            let layout = Layout::from_size_align(alignment, alignment).unwrap();
-            let ptr = unsafe { ALLOC.alloc(layout) };
-            assert_ne!(ptr, null_mut());
+        for alloc in (0..16).map(|i| i << 1) {
+            for alignment in (0..16).map(|i| 1 << i) {
+                let layout = Layout::from_size_align(alloc, alignment).unwrap();
+                let ptr = unsafe { ALLOC.alloc(layout) };
+                assert_ne!(ptr, null_mut());
 
-            assert_eq!(total_memory_usage(), alignment);
-            assert_eq!(ptr as usize % alignment, 0);
+                assert_eq!(ptr as usize % alignment, 0);
 
-            unsafe { ALLOC.dealloc(ptr, layout) };
+                unsafe { ALLOC.dealloc(ptr, layout) };
+            }
         }
     }
 
@@ -397,15 +398,16 @@ mod test {
     #[serial_test::serial]
     fn test_alignment_with_offset() {
         let header_size = mem::size_of::<AllocHeader>();
-        for alignment in (0..16).map(|i| 1 << i).filter(|&p| p >= header_size) {
-            let layout = Layout::from_size_align(alignment, alignment).unwrap();
-            let ptr = unsafe { ALLOC.alloc(layout) };
-            assert_ne!(ptr, null_mut());
+        for alloc in (0..16).map(|i| i << 1).filter(|&alloc| alloc > header_size) {
+            for alignment in (0..16).map(|i| 1 << i).filter(|&p| p >= header_size) {
+                let layout = Layout::from_size_align(alloc - header_size, alignment).unwrap();
+                let ptr = unsafe { ALLOC.alloc(layout) };
+                assert_ne!(ptr, null_mut());
 
-            assert_eq!(total_memory_usage(), alignment);
-            assert_eq!(ptr as usize % alignment, 0);
+                assert_eq!(ptr as usize % alignment, 0);
 
-            unsafe { ALLOC.dealloc(ptr, layout) };
+                unsafe { ALLOC.dealloc(ptr, layout) };
+            }
         }
     }
 }


### PR DESCRIPTION
There was a bug, where the requested data wouldn't get aligned properly for alignments that are at least 64 bytes. That doesn't happen. However, it worth fixing the bug and adding at test. See https://github.com/near/near-memory-tracker/pull/85#discussion_r778322209

This PR adds ad test.