### PR TITLE
Remove unused `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,6 @@ dependencies = [
  "backtrace",
  "criterion",
  "nix",
- "once_cell",
  "serial_test",
  "tikv-jemallocator",
  "tracing",

--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["memory-management"]
 [dependencies]
 backtrace = "0.3"
 nix = ">=0.15,<=0.23"
-once_cell = "1"
 tracing = "0.1.13"
 
 [dev-dependencies]


### PR DESCRIPTION
`once_cell` is unused, let's remove it.