### PR TITLE
Release `rust-memory-analyzer` to public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 name = "example-target"
 version = "0.1.0"
 dependencies = [
- "near-rust-allocator-proxy",
+ "near-rust-allocator-proxy 0.4.0",
  "tikv-jemallocator",
  "tracing",
  "tracing-subscriber",
@@ -423,6 +423,17 @@ dependencies = [
  "tikv-jemallocator",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "near-rust-allocator-proxy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be44da452581a4f2e7870d86886f50605853943ded9b6a7975495914645cdca4"
+dependencies = [
+ "backtrace",
+ "nix",
+ "tracing",
 ]
 
 [[package]]
@@ -651,7 +662,7 @@ dependencies = [
  "clap 3.0.0-rc.7",
  "clap_derive",
  "itertools",
- "near-rust-allocator-proxy",
+ "near-rust-allocator-proxy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix",
  "rustc-demangle",
  "tracing",

--- a/deny.toml
+++ b/deny.toml
@@ -157,7 +157,6 @@ wildcards = "allow"
 highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
@@ -171,6 +170,7 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
+    { name = "near-rust-allocator-proxy", version = "=0.4.0" },
     { name = "itoa", version = "=0.4.8" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate

--- a/rust-memory-analyzer/Cargo.toml
+++ b/rust-memory-analyzer/Cargo.toml
@@ -7,10 +7,9 @@ edition = "2021"
 anyhow = "1.0.51"
 clap = "=3.0.0-rc.7"
 clap_derive = "=3.0.0-rc.7"
-itertools =  { version = "0.10.3", features = ["use_alloc", "use_std"] }
+itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
+near-rust-allocator-proxy = "0.4.0"
 nix = "0.23.1"
 rustc-demangle = "=0.1.21"
 tracing = "0.1.29"
 tracing-subscriber = "0.3.3"
-
-near-rust-allocator-proxy = { path = "../near-rust-allocator-proxy" }


### PR DESCRIPTION
` rust-memory-analyzer` can be shipped to public, but we need to change dependencies to depend on `crates.io`.