### PR TITLE
chore: bump jemalloc version to 0.5.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
       if: steps.deny-cache.outputs.cache-hit != 'true'
       run: cargo install cargo-deny
     - name: Run cargo-deny
-      run: cargo-deny --all-features --workspace check Advisories Bans Sources
+      run: cargo-deny --all-features --workspace check advisories bans sources
 
   cargo-fmt:
     runs-on: ubuntu-20.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "regex-syntax",
 ]
@@ -644,9 +644,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rust-memory-analyzer"
@@ -823,10 +823,11 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,12 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,20 +832,19 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.4.2+5.2.1-patched.2"
+version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5844e429d797c62945a566f8da4e24c7fe3fbd5d6617fd8bf7a0b7dc1ee0f22e"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
 dependencies = [
  "cc",
- "fs_extra",
  "libc",
 ]
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.4.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/example-target/Cargo.toml
+++ b/example-target/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-tikv-jemallocator = "0.4.1"
+tikv-jemallocator = "0.5"
 tracing = "0.1.13"
 tracing-subscriber = "0.3.3"
 

--- a/near-rust-allocator-proxy/Cargo.toml
+++ b/near-rust-allocator-proxy/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.13"
 [dev-dependencies]
 criterion = "0.3.5"
 serial_test = "0.5.1"
-tikv-jemallocator = "0.4.1"
+tikv-jemallocator = "0.5"
 tracing-subscriber = "0.3.3"
 
 [[bench]]

--- a/rust-memory-analyzer/src/analyze.rs
+++ b/rust-memory-analyzer/src/analyze.rs
@@ -92,9 +92,7 @@ impl AnalyzeCmd {
         let present_allocated_with_proxy = ptr_2_memory.iter().map(|x| x.1.size).sum();
         for (ptr, val) in ptr_2_memory.iter() {
             let symbol_mappings = (mmaped_exec.iter())
-                .filter(|x| {
-                    ((x.from as *mut c_void) <= (*ptr)) && ((*ptr as usize) < x.to)
-                })
+                .filter(|x| ((x.from as *mut c_void) <= (*ptr)) && ((*ptr as usize) < x.to))
                 .filter_map(|smap| {
                     let file_offset = (*ptr as usize) - smap.from + smap.offset;
 

--- a/rust-memory-analyzer/src/analyze.rs
+++ b/rust-memory-analyzer/src/analyze.rs
@@ -93,10 +93,10 @@ impl AnalyzeCmd {
         for (ptr, val) in ptr_2_memory.iter() {
             let symbol_mappings = (mmaped_exec.iter())
                 .filter(|x| {
-                    ((x.from as *mut c_void) <= (*ptr)) && ((*ptr as usize) < x.to as usize)
+                    ((x.from as *mut c_void) <= (*ptr)) && ((*ptr as usize) < x.to)
                 })
                 .filter_map(|smap| {
-                    let file_offset = (*ptr as usize) - smap.from as usize + smap.offset as usize;
+                    let file_offset = (*ptr as usize) - smap.from + smap.offset;
 
                     if let Some(last_sym) =
                         symbols.iter().filter(|s| s.offset <= file_offset).last()

--- a/rust-memory-analyzer/src/symbols.rs
+++ b/rust-memory-analyzer/src/symbols.rs
@@ -28,7 +28,7 @@ impl SymbolsCmd {
 }
 
 pub fn get_symbols(binary_path: &str) -> anyhow::Result<Vec<Symbol>> {
-    let output = (Command::new("nm").arg("-an").arg(&binary_path))
+    let output = (Command::new("nm").arg("-an").arg(binary_path))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()?;

--- a/rust-memory-analyzer/src/utils.rs
+++ b/rust-memory-analyzer/src/utils.rs
@@ -10,7 +10,7 @@ pub const MIB: usize = 1 << 20;
 
 pub fn read_lines(file_name: impl AsRef<Path>) -> anyhow::Result<impl Iterator<Item = String>> {
     let file = File::open(file_name)?;
-    Ok(io::BufReader::new(file).lines().filter_map(|x| x.ok()))
+    Ok(io::BufReader::new(file).lines().map_while(|x| x.ok()))
 }
 
 pub fn read_smaps(pid: i32) -> anyhow::Result<Vec<Smap>> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-# Please update rust-version in **/Cargo.toml files when changing channel:
-channel = "1.57.0"
+channel = "1.72.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Bumping the version to make it compatible with latest neard. Also requires a rust version bump because of `tikv-jemalloc-sys` build commands that rely on newer rust.

Fore more context:
In nearcore, we currently use tikv-jemallocator 0.5.0 which uses jemalloc version 0.5.3. This makes it incompatible with tikv-jemallocator 0.4.*

`tikv-jemalloc-sys` 0.5 uses build commands with named arguments in `println!` which is only supported since Rust 1.58.0. Bumping to latest Rust to follow the same practice as we do in nearcore.